### PR TITLE
Some enhancements to the existing functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ _testmain.go
 *.exe
 *.test
 *.swp
+
+# IDE metadata
+**/.settings/
+**/.idea/
+**/*.iml

--- a/README.md
+++ b/README.md
@@ -7,12 +7,27 @@ usage
 =====
 gitversion -i pathToRepository -o pathToVersionFile -p packageName
 
--i defaults to .<br>
--o defaults to version.go<br>
--p defaults to version<br>
+-i  defaults to .<br>
+-o  defaults to version.go<br>
+-p  defaults to version<br>
+-tf adds human readable timestamp format (see [time](http://golang.org/pkg/time/#pkg-constants) package)<br>
+-v  adds version string (e.g., "1.0-Final")<br>
+-s  uses short git commit hash
 
 template
 ========
+```go
 package %s
 
-var GIT_COMMIT_HASH = "%s"
+const (
+	GIT_COMMIT_HASH = "%s"
+
+	// Unix time (seconds since January 1, 1970 UTC)
+	GENERATED = %d
+
+	// human readable timestamp
+	GENERATED_FMT = "%s"  // only if "-tf" option specified
+
+	VERSION = "%s"        // only if "-v" option specified
+)
+```


### PR DESCRIPTION
Hello,
I made some changes needed for my current project.  There were a couple of (possibly) breaking changes:
1.  Define the generated values as constants instead of variables.  It made more sense to me to use constants, as I wouldn't want these values being changed at runtime.  The names are the same, so this would only break if someone was actually trying to assign a different value.
2.  Change the timestamp from `UnixNano()` to `Unix()`.  There just didn't seem to be a need for nanosecond resolution on build time.

The rest of the changes are additive, and don't break existing functionality:
1.  Add optional human-readable timestamp
1.  Add optional version string
1.  Search upward for git root
1.  Use text/template instead of fmt.Sprintf to generate file contents

I know these are some significant changes from what you had already done, so if you don't want to accept them it's no problem and I can just continue to use my fork.

Thanks!
